### PR TITLE
fix: skip frame instead of panicking when surface is occluded

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,17 +529,18 @@ impl Renderer {
         let surface_texture = match self.gpu.surface.get_current_texture() {
             wgpu::CurrentSurfaceTexture::Success(frame)
             | wgpu::CurrentSurfaceTexture::Suboptimal(frame) => frame,
-            wgpu::CurrentSurfaceTexture::Outdated => {
+            wgpu::CurrentSurfaceTexture::Outdated | wgpu::CurrentSurfaceTexture::Lost => {
                 self.gpu
                     .surface
                     .configure(&self.gpu.device, &self.gpu.surface_config);
                 match self.gpu.surface.get_current_texture() {
                     wgpu::CurrentSurfaceTexture::Success(frame)
                     | wgpu::CurrentSurfaceTexture::Suboptimal(frame) => frame,
-                    other => {
-                        panic!("Failed to get surface texture after reconfiguration: {other:?}")
-                    }
+                    _ => return,
                 }
+            }
+            wgpu::CurrentSurfaceTexture::Occluded | wgpu::CurrentSurfaceTexture::Timeout => {
+                return;
             }
             other => panic!("Failed to get surface texture: {other:?}"),
         };

--- a/src/raytracing.rs
+++ b/src/raytracing.rs
@@ -981,8 +981,11 @@ impl RayTracer {
         let surface_texture = match self.surface.get_current_texture() {
             wgpu::CurrentSurfaceTexture::Success(frame)
             | wgpu::CurrentSurfaceTexture::Suboptimal(frame) => frame,
-            wgpu::CurrentSurfaceTexture::Outdated => {
+            wgpu::CurrentSurfaceTexture::Outdated | wgpu::CurrentSurfaceTexture::Lost => {
                 self.surface.configure(&self.device, &self.surface_config);
+                return;
+            }
+            wgpu::CurrentSurfaceTexture::Occluded | wgpu::CurrentSurfaceTexture::Timeout => {
                 return;
             }
             other => panic!("Failed to acquire surface texture: {other:?}"),


### PR DESCRIPTION
## Problem

Running the ray tracing demo on macOS aborts the whole process whenever the window is not visible — covered by another window, minimized, or occluded during the first redraw:

```
thread 'main' (2774711) panicked at src/raytracing.rs:988:22:
Failed to acquire surface texture: Occluded
...
thread 'main' (2774711) panicked at .../core/src/panicking.rs:225:5:
panic in a function that cannot unwind
  12: winit::platform_impl::macos::view::WinitView::draw_rect
thread caused non-unwinding panic. aborting.
```

Two things compound here:

1. `Surface::get_current_texture()` returns `CurrentSurfaceTexture::Occluded` on macOS whenever the window isn't actually on screen. The wgpu docs for this state say: *"Applications should skip the current frame and try again once the window is no longer occluded"* — but both render paths (`raytracing.rs` and the main app in `lib.rs`) hit the catch-all `panic!` instead.
2. The panic fires inside winit's macOS `draw_rect` callback, which is a non-unwinding context — so instead of a normal panic, the process hard-aborts.

Reproduced on an Apple M4 (macOS, Metal backend): launching `cargo run -r --bin rt` with the window occluded aborts within the first frame.

## Fix

Handle each acquisition state the way the wgpu docs prescribe, in both render paths:

- `Occluded` / `Timeout` → skip the frame and try again on the next redraw
- `Lost` → reconfigure the surface, same as the existing `Outdated` handling
- `Validation` → still panics, since that indicates a real programming error

## Verification

Before: launching `rt` with the window occluded aborts within ~1s with the trace above.
After: the same scenario runs indefinitely (tested 15s occluded, no panic), and the demo renders normally once visible. Both `cargo build -r` and `cargo build -r --bin rt` compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)